### PR TITLE
Update terminal colors

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,3 +1,6 @@
 default:
   extension: .json
   output: themes
+default-256:
+  extension: -256.json
+  output: themes

--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -1,5 +1,5 @@
 {
-    "name": "Base16 {{scheme-name}}",
+    "name": "Base16 {{scheme-name}} 256",
     "type": "dark",
     "colors": {
         // Contrast colors
@@ -267,20 +267,20 @@
         "terminal.background": "#{{base00-hex}}", //0
         "terminal.foreground": "#{{base05-hex}}", //5
         "terminal.ansiBlack": "#{{base00-hex}}", //0
-        "terminal.ansiRed": "#{{base08-hex}}", //8
-        "terminal.ansiGreen": "#{{base0B-hex}}", //B
-        "terminal.ansiYellow": "#{{base0A-hex}}", //A
-        "terminal.ansiBlue": "#{{base0D-hex}}", //D
-        "terminal.ansiMagenta": "#{{base0E-hex}}", //E
-        "terminal.ansiCyan": "#{{base0C-hex}}", //C
-        "terminal.ansiWhite": "#{{base05-hex}}", //5
         "terminal.ansiBrightBlack": "#{{base03-hex}}", //3
-        "terminal.ansiBrightRed": "#{{base09-hex}}", //9
-        "terminal.ansiBrightGreen": "#{{base01-hex}}", //1
-        "terminal.ansiBrightYellow": "#{{base02-hex}}", //2
-        "terminal.ansiBrightBlue": "#{{base04-hex}}", //4
-        "terminal.ansiBrightMagenta": "#{{base06-hex}}", //6
-        "terminal.ansiBrightCyan": "#{{base0F-hex}}", //F
+        "terminal.ansiRed": "#{{base08-hex}}", //8
+        "terminal.ansiBrightRed": "#{{base08-hex}}", //8
+        "terminal.ansiYellow": "#{{base0A-hex}}", //A
+        "terminal.ansiBrightYellow": "#{{base0A-hex}}", //A
+        "terminal.ansiGreen": "#{{base0B-hex}}", //B
+        "terminal.ansiBrightGreen": "#{{base0B-hex}}", //B
+        "terminal.ansiCyan": "#{{base0C-hex}}", //C
+        "terminal.ansiBrightCyan": "#{{base0C-hex}}", //C
+        "terminal.ansiBlue": "#{{base0D-hex}}", //D
+        "terminal.ansiBrightBlue": "#{{base0D-hex}}", //D
+        "terminal.ansiMagenta": "#{{base0E-hex}}", //E
+        "terminal.ansiBrightMagenta": "#{{base0E-hex}}", //E
+        "terminal.ansiWhite": "#{{base05-hex}}", //5
         "terminal.ansiBrightWhite": "#{{base07-hex}}", //7
 
         // Debug


### PR DESCRIPTION
Fix terminal colors in default color scheme according to https://github.com/chriskempson/base16-xresources (and the rest of the terminal color scheme repos).
Add 256 color scheme template that doesn't make bright colors behave unexpectedly according to https://github.com/chriskempson/base16-shell.