### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Sanders Lauture
+Copyright (c) 2022 Tinted Theming
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base16 for Visual Studio Code
 
-See the [Base16 Project repository](https://github.com/base16-project/home) for more info.
+See the [tinted-theming repository](https://github.com/tinted-theming/home) for more info.
 
 ## Installation
 


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.