### PR TITLE
Fix reference to legacy vscode app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tinted VSCode
 
 This [VSCode extension] adds all [Base16] and [Base24] themes to your
-VSCode theme list. You can have a look at the [Base16 Gallery] to
+VSCode theme list. You can have a look at the [Tinted Gallery] to
 preview the available themes. Look at [Tinted Theming] for more
 information.
 
@@ -9,7 +9,7 @@ information.
 
 1. Go to your Extensions view in VSCode File -> Preferences ->
    Extensions or `CTRL + SHIFT + x`
-2. Search for `Base16 Theme Switcher` and install
+2. Search for `Tinted VSCode` and install
 
 ## Usage
 
@@ -19,7 +19,7 @@ information.
 2. Filter and select the theme you want to use.
 
 [VSCode extension]: https://marketplace.visualstudio.com/items?itemName=TintedTheming.base16-tinted-themes
-[Base16 Gallery]: https://tinted-theming.github.io/base16-gallery/
+[Tinted Gallery]: https://tinted-theming.github.io/tinted-gallery/
 [Tinted Theming]: https://github.com/tinted-theming/home
 [Base16]: https://github.com/tinted-theming/home/blob/main/styling.md
 [Base24]: https://github.com/tinted-theming/base24


### PR DESCRIPTION
Related: https://github.com/tinted-theming/tinted-vscode/issues/9